### PR TITLE
Added equals and hashcode to LinkValue types

### DIFF
--- a/core/src/main/java/com/ibm/common/activitystreams/LinkValue.java
+++ b/core/src/main/java/com/ibm/common/activitystreams/LinkValue.java
@@ -25,6 +25,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.Serializable;
 import java.util.Iterator;
+import java.util.Objects;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
@@ -160,7 +161,24 @@ public interface LinkValue
       super(builder);
       this.iri = builder.iri;
     }
-    
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(iri);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+          return false;
+      SimpleLinkValue other = (SimpleLinkValue) obj;
+      return Objects.equals(iri,other.iri);
+    }
+
     /**
      * Return the url
      * @return String 
@@ -289,7 +307,24 @@ public interface LinkValue
       super(builder);
       this.links = builder.links.build();
     }
-    
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(links);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+        return false;
+      ArrayLinkValue other = (ArrayLinkValue) obj;
+      return Objects.equals(links,other.links);
+    }
+
     /**
      * Method iterator.
      * @return Iterator<LinkValue> 

--- a/core/src/test/java/com/ibm/common/activitystreams/test/TestBasics.java
+++ b/core/src/test/java/com/ibm/common/activitystreams/test/TestBasics.java
@@ -91,7 +91,18 @@ public final class TestBasics {
     assertEquals("Foo", map.value("en"));
     assertEquals("Bar", map.value("fr"));
   }
-  
+
+  @Test
+  public void testLinkValue() {
+      ASObject obj1 = Makers.object().attachments("Foo").get();
+      ASObject obj2 = Makers.object().attachments("Foo").get();
+      assertEquals(obj1.attachments(), obj2.attachments());
+
+      ASObject obj3 = Makers.object().attachments("Foo", "Bar").get();
+      ASObject obj4 = Makers.object().attachments("Foo", "Bar").get();
+      assertEquals(obj3.attachments(), obj4.attachments());
+  }
+
   @Test
   public void testDateTimes() {
     DateTime now = DateTime.now();


### PR DESCRIPTION
- Any activity which contained a LinkValue could never be equal to another activity because LinkValues previously did not have equals overridden.  The simple and array link value types now override equals and hashcode.
- Added a test for LinkValue equality.
